### PR TITLE
Integrate AFD engine with state persistence and alert routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ N8N_HOST=localhost
 N8N_PROTOCOL=http
 WEBHOOK_URL=http://localhost:5678
 N8N_LOG_LEVEL=info
+CASCADE_THRESHOLD=3
+CASCADE_WINDOW=60
 
 # Cle de chiffrement n8n
 # Generer avec : openssl rand -hex 32

--- a/workflows/feedback.json
+++ b/workflows/feedback.json
@@ -1,709 +1,752 @@
 {
-    "name": "Feedback workflow",
-    "nodes": [
-        {
-            "parameters": {
-                "httpMethod": "POST",
-                "path": "/whatsapp-feedback",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.webhook",
-            "typeVersion": 2.1,
-            "position": [
-                -880,
-                496
-            ],
-            "id": "3fcf0813-0fd5-47d7-b38d-cc1775ca4943",
-            "name": "WhatsApp Feedback Webhook",
-            "webhookId": "fb262572-5df0-4631-8114-2ce8c96ac0db"
-        },
-        {
-            "parameters": {
-                "jsCode": "// 1. Get WhatsApp data directly from the Webhook node\n// Replace 'WhatsApp Feedback Webhook' with the exact name of your webhook node\nconst webhookData = $('WhatsApp Feedback Webhook').item.json;\nconst body = webhookData.body?.Body?.trim()?.toUpperCase() || \"\";\nconst from = webhookData.body?.From;\n\n// 2. Get context data from the Postgres node (the current input)\nconst source_id = $json.source_id || null;\nconst afd_state = $json.afd_state || null;\nconst message = $json.message || null;\n\nlet result = {\n  type: \"UNKNOWN\",\n  new_state: afd_state,\n  raw: body,\n  from: from,\n  source_id: source_id,\n  afd_state: afd_state,\n  message: message\n};\n\n// 3. Command Logic\n// 3. Improved Command Logic using .startsWith()\nif (body.startsWith(\"ACK\")) {\n    result.type = \"ACK\";\n} \nelse if (body.startsWith(\"FALSE POSITIVE\")) {\n    result.type = \"FALSE_POSITIVE\";\n} \nelse if (body.startsWith(\"CORRIGER WARNING\")) {\n    result.type = \"CORRIGER\";\n    result.new_state = \"WARNING\";\n} \nelse if (body.startsWith(\"CORRIGER ERROR\")) {\n    result.type = \"CORRIGER\";\n    result.new_state = \"ERROR\";\n} \nelse if (body.startsWith(\"RESOLVED\")) {\n    result.type = \"RESOLVED\";\n} \nelse if (body.startsWith(\"STATUS\")) {\n    result.type = \"STATUS\";\n} \nelse if (body.startsWith(\"ESCALATE\")) {\n    result.type = \"ESCALATE\";\n} \nelse if (body.startsWith(\"HELP\")) {\n    result.type = \"HELP\";\n}\n\nreturn [{ json: result }];"
-            },
-            "type": "n8n-nodes-base.code",
-            "typeVersion": 2,
-            "position": [
-                -208,
-                496
-            ],
-            "id": "28b2ce78-5b16-4870-b91b-15f3442344b6",
-            "name": "Parse Feedback Command"
-        },
-        {
-            "parameters": {
-                "rules": {
-                    "values": [
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "ACK",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals"
-                                        },
-                                        "id": "281a8952-88b5-4e80-b040-bee34eaaaad0"
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "ACK Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "ef17d727-271c-49bc-90f5-f9f6be3da846",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "FALSE_POSITIVE",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "FALSE_POSITIVE Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "13578fcd-a1e0-4756-a4e0-d65f6f43f4fb",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "CORRIGER",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "CORRIGER Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "469048e2-dafc-4890-8e63-14edfe983853",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "RESOLVED",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "RESOLVED Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "b5049b40-9760-4847-8431-3601f3feab9b",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "STATUS",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "STATUS Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "8b538c7e-c3bb-458b-95de-df043d6bcfa6",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "ESCALATE",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "ESCALATE Handler"
-                        },
-                        {
-                            "conditions": {
-                                "options": {
-                                    "caseSensitive": true,
-                                    "leftValue": "",
-                                    "typeValidation": "strict",
-                                    "version": 3
-                                },
-                                "conditions": [
-                                    {
-                                        "id": "59311c52-9c8b-4085-95f0-132bc4a59089",
-                                        "leftValue": "={{$json.type}}",
-                                        "rightValue": "HELP",
-                                        "operator": {
-                                            "type": "string",
-                                            "operation": "equals",
-                                            "name": "filter.operator.equals"
-                                        }
-                                    }
-                                ],
-                                "combinator": "and"
-                            },
-                            "renameOutput": true,
-                            "outputKey": "HELP Handler"
-                        }
-                    ]
+  "name": "Feedback workflow",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "/whatsapp-feedback",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2.1,
+      "position": [
+        -1120,
+        576
+      ],
+      "id": "8abeebcb-43aa-4fa4-8517-5ba44f2e84fd",
+      "name": "WhatsApp Feedback Webhook",
+      "webhookId": "fb262572-5df0-4631-8114-2ce8c96ac0db"
+    },
+    {
+      "parameters": {
+        "jsCode": "// 1. Get WhatsApp data directly from the Webhook node\n// Replace 'WhatsApp Feedback Webhook' with the exact name of your webhook node\nconst webhookData = $('WhatsApp Feedback Webhook').item.json;\nconst body = webhookData.body?.Body?.trim()?.toUpperCase() || \"\";\nconst from = webhookData.body?.From;\n\n// 2. Get context data from the Postgres node (the current input)\nconst source_id = $json.source_id || null;\nconst afd_state = $json.afd_state || null;\nconst message = $json.message || null;\n\nlet result = {\n  type: \"UNKNOWN\",\n  new_state: afd_state,\n  raw: body,\n  from: from,\n  source_id: source_id,\n  afd_state: afd_state,\n  message: message\n};\n\n// 3. Command Logic\n// 3. Improved Command Logic using .startsWith()\nif (body.startsWith(\"ACK\")) {\n    result.type = \"ACK\";\n} \nelse if (body.startsWith(\"FALSE POSITIVE\")) {\n    result.type = \"FALSE_POSITIVE\";\n} \nelse if (body.startsWith(\"CORRIGER WARNING\")) {\n    result.type = \"CORRIGER\";\n    result.new_state = \"WARNING\";\n} \nelse if (body.startsWith(\"CORRIGER ERROR\")) {\n    result.type = \"CORRIGER\";\n    result.new_state = \"ERROR\";\n} \nelse if (body.startsWith(\"RESOLVED\")) {\n    result.type = \"RESOLVED\";\n} \nelse if (body.startsWith(\"STATUS\")) {\n    result.type = \"STATUS\";\n} \nelse if (body.startsWith(\"ESCALATE\")) {\n    result.type = \"ESCALATE\";\n} \nelse if (body.startsWith(\"HELP\")) {\n    result.type = \"HELP\";\n}\n\nreturn [{ json: result }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -448,
+        576
+      ],
+      "id": "666ffb38-1c67-4e17-8dbf-1c7e555b7902",
+      "name": "Parse Feedback Command"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
                 },
-                "options": {}
+                "conditions": [
+                  {
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "ACK",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "id": "281a8952-88b5-4e80-b040-bee34eaaaad0"
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "ACK Handler"
             },
-            "type": "n8n-nodes-base.switch",
-            "typeVersion": 3.4,
-            "position": [
-                16,
-                416
-            ],
-            "id": "84c2e38f-9f8e-4dbc-b0bb-1e8416d25d08",
-            "name": "Feedback Router"
-        },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "\nUPDATE afd_states \nSET \n    current_state = 'NOMINAL',\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}';\n\n\nINSERT INTO feedback_corrections (source_id, original_state, corrected_state, command_used)\nVALUES ('{{ $json.source_id }}', '{{ $json.afd_state }}', 'NOMINAL', 'FALSE_POSITIVE');",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                240,
-                112
-            ],
-            "id": "50b0faab-3156-4c1c-a7c0-f95e44faf93e",
-            "name": "FALSE_POSITIVE Handler"
-        },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "INSERT INTO feedback_corrections (source_id, corrected_state, corrected_at)\nVALUES (\n  '{{$json.source_id}}',\n  '{{$json.new_state}}',\n  NOW()\n);\n\nUPDATE afd_states \nSET \n    current_state = '{{ $json.new_state }}',\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}'\nRETURNING current_state;",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                240,
-                304
-            ],
-            "id": "6a6bcd11-4fbd-496e-b316-772096128aa2",
-            "name": "CORRIGER Handler"
-        },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "\nUPDATE afd_states \nSET \n    current_state = 'NOMINAL',\n    ack_time = COALESCE(ack_time, last_event_time),\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}'\nRETURNING EXTRACT(EPOCH FROM (NOW() - last_event_time))::integer AS mttr_seconds;",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                240,
-                496
-            ],
-            "id": "322b877a-364c-43d9-ae38-3986eb094988",
-            "name": "RESOLVED Handler"
-        },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "SELECT \n    source_id, \n    current_state, \n    last_event_time \nFROM afd_states \nORDER BY current_state DESC, last_event_time DESC;",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                240,
-                688
-            ],
-            "id": "1b20716e-cd55-46f8-a446-afe0440f3003",
-            "name": "STATUS Handler"
-        },
-        {
-            "parameters": {
-                "method": "POST",
-                "url": "=https://api.twilio.com/2010-04-01/Accounts/{{$env.TWILIO_ACCOUNT_SID}}/Messages.json",
-                "authentication": "genericCredentialType",
-                "genericAuthType": "httpBasicAuth",
-                "sendBody": true,
-                "contentType": "form-urlencoded",
-                "bodyParameters": {
-                    "parameters": [
-                        {
-                            "name": "From",
-                            "value": "={{$env.TWILIO_WHATSAPP_FROM}}"
-                        },
-                        {
-                            "name": "To",
-                            "value": "={{$env.TWILIO_WHATSAPP_ESCALATION}}"
-                        },
-                        {
-                            "name": "Body",
-                            "value": "={{ $json.message}}"
-                        }
-                    ]
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
                 },
-                "options": {}
+                "conditions": [
+                  {
+                    "id": "ef17d727-271c-49bc-90f5-f9f6be3da846",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "FALSE_POSITIVE",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "FALSE_POSITIVE Handler"
             },
-            "type": "n8n-nodes-base.httpRequest",
-            "typeVersion": 4.4,
-            "position": [
-                688,
-                496
-            ],
-            "id": "14fbbcf7-5a09-4778-952c-49da5e9bb165",
-            "name": "Escalation Alert (Twilio)"
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "13578fcd-a1e0-4756-a4e0-d65f6f43f4fb",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "CORRIGER",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "CORRIGER Handler"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "469048e2-dafc-4890-8e63-14edfe983853",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "RESOLVED",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "RESOLVED Handler"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "b5049b40-9760-4847-8431-3601f3feab9b",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "STATUS",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "STATUS Handler"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "8b538c7e-c3bb-458b-95de-df043d6bcfa6",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "ESCALATE",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "ESCALATE Handler"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "59311c52-9c8b-4085-95f0-132bc4a59089",
+                    "leftValue": "={{$json.type}}",
+                    "rightValue": "HELP",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals",
+                      "name": "filter.operator.equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "HELP Handler"
+            }
+          ]
         },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "UPDATE afd_states \nSET \n    ack_time = NOW(),\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}';",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                240,
-                -80
-            ],
-            "id": "bf80453a-d4b4-4553-989d-3679dac74870",
-            "name": "ACK Handler"
-        },
-        {
-            "parameters": {
-                "operation": "executeQuery",
-                "query": "(\n  -- First attempt: Find the specific service extracted from WhatsApp\n  SELECT \n      a.source_id, \n      a.current_state AS afd_state,\n      (SELECT message FROM logs l WHERE l.source_id = a.source_id ORDER BY classified_at DESC LIMIT 1) AS message,\n      1 as priority\n  FROM afd_states a\n  WHERE a.source_id = '{{ $json.extracted_service }}'\n)\nUNION ALL\n(\n  -- Fallback: If the above doesn't exist, get the most recent service overall\n  SELECT \n      a.source_id, \n      a.current_state AS afd_state,\n      (SELECT message FROM logs l WHERE l.source_id = a.source_id ORDER BY classified_at DESC LIMIT 1) AS message,\n      2 as priority\n  FROM afd_states a\n  ORDER BY a.last_event_time DESC\n  LIMIT 1\n)\nORDER BY priority ASC\nLIMIT 1;",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.postgres",
-            "typeVersion": 2.6,
-            "position": [
-                -432,
-                496
-            ],
-            "id": "45ff5bb5-4d8f-42b4-8538-77ef9ce0d8ae",
-            "name": "Fetch alert context"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "{\n  \"message\": \"*PRISE EN CHARGE ENREGISTREE*\\n\\nL'intervention humaine a bien été notée dans le système.\"\n}",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                -80
-            ],
-            "id": "e61799de-987e-40ae-818a-92baf5fb3126",
-            "name": "ACK Message"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "{\n  \"message\": \"*RECLASSIFICATION REUSSIE*\\n\\nLe système a enregistré cette erreur de classification.\\nL'état du service est repassé en NOMINAL.\"\n}",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                112
-            ],
-            "id": "d6c0ebc0-bace-4b4c-8eca-07a32bad3c0c",
-            "name": "FALSE_POSITIVE Message"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "={\n  \"message\": \"*RECLASSIFICATION APPLIQUÉE*\\n\\nLe service a été reclassifié avec succès en *{{ $json.current_state }}*.\"\n}",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                304
-            ],
-            "id": "3825eb92-0a2d-4737-8798-d11bdde66e77",
-            "name": "CORRIGER Message"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "={\n  \"message\": \"*INCIDENT RÉSOLU*\\n\\nLe service est repassé en état NOMINAL.\\n\\n*MTTR :* {{ Math.floor($json.mttr_seconds / 60) }} minutes.\"\n}\n",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                496
-            ],
-            "id": "c9a6877e-1c2a-4e55-9f27-d9117a95cbab",
-            "name": "RESOLVED Message"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "={ \n  \"message\": \"*ESCALATION REQUEST*\\n*Service:* apache\\n*State:* CRITICAL\\n*Message:* 127.0.0.1 - - [15/Jan/2024:14:23:01 +0000] \\\"POST /api/checkout 500 124\\\" CRITICAL: Database connection pool exhausted\\n\\n*Immediate intervention required*\" \n}",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                880
-            ],
-            "id": "7001c817-cc85-4685-803f-52dd0335bad9",
-            "name": "ESCALATE Message"
-        },
-        {
-            "parameters": {
-                "mode": "raw",
-                "jsonOutput": "{\n  \"message\": \"GUIDE DES COMMANDES DISPONIBLES\\n\\n*ACK* : Confirmer la prise en charge de l'alerte.\\n\\n*FALSE POSITIVE* : Signaler une erreur de classification (l'état repassera en NOMINAL).\\n\\n*CORRIGER [ETAT]* : Forcer manuellement un nouvel état.\\nExemple : CORRIGER WARNING\\n\\n*RESOLVED* : Clôturer l'incident et calculer le temps de résolution (MTTR).\\n\\n*STATUS* : Obtenir l'état actuel de tous les services monitorés.\\n\\n*ESCALATE* : Transférer l'alerte à l'astreinte de niveau supérieur.\\n\\n*HELP* : Afficher ce menu d'aide.\"\n}",
-                "options": {}
-            },
-            "type": "n8n-nodes-base.set",
-            "typeVersion": 3.4,
-            "position": [
-                464,
-                1072
-            ],
-            "id": "ff61c00b-42e5-4630-bdbc-1e968fd4e039",
-            "name": "HELP Message"
-        },
-        {
-            "parameters": {
-                "jsCode": "const items = $input.all();\nlet statusList = items.map(item => {\n  return `• *${item.json.source_id}*: ${item.json.current_state}`;\n}).join('\\n');\n\nreturn {\n  message: `État actuel des services :*\\n${statusList}`\n};"
-            },
-            "type": "n8n-nodes-base.code",
-            "typeVersion": 2,
-            "position": [
-                464,
-                688
-            ],
-            "id": "9cf00f6a-16c0-49ce-990f-8d23844e23b3",
-            "name": "STATUS Message"
-        },
-        {
-            "parameters": {
-                "jsCode": "// On récupère le texte avec la majuscule \"Body\"\nconst text = $input.item.json.body.Body; \n\nif (!text) {\n  return { extracted_service: \"unknown\" };\n}\n\n// On sépare les mots\nconst parts = text.split(\" \");\n\n/* Si l'admin écrit \"ESCALATE payment-api\" :\n  parts[0] = \"ESCALATE\"\n  parts[1] = \"payment-api\"\n*/\nconst service = parts[1] ? parts[1].toLowerCase() : \"all\"; \n\nreturn {\n  extracted_service: service\n};"
-            },
-            "type": "n8n-nodes-base.code",
-            "typeVersion": 2,
-            "position": [
-                -656,
-                496
-            ],
-            "id": "d8775a29-f177-4478-a04b-01029b6c3441",
-            "name": "Extract Service"
+        "options": {}
+      },
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.4,
+      "position": [
+        -224,
+        496
+      ],
+      "id": "0c7f4c0f-6ef6-4a2f-93a2-0241889356ba",
+      "name": "Feedback Router"
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "\nUPDATE afd_states \nSET \n    current_state = 'NOMINAL',\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}';\n\n\nINSERT INTO feedback_corrections (source_id, original_state, corrected_state, command_used)\nVALUES ('{{ $json.source_id }}', '{{ $json.afd_state }}', 'NOMINAL', 'FALSE_POSITIVE');",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        0,
+        192
+      ],
+      "id": "593d08ff-64f6-4806-9d49-46f2117bec6a",
+      "name": "FALSE_POSITIVE Handler",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
         }
-    ],
-    "pinData": {},
-    "connections": {
-        "WhatsApp Feedback Webhook": {
-            "main": [
-                [
-                    {
-                        "node": "Extract Service",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "Parse Feedback Command": {
-            "main": [
-                [
-                    {
-                        "node": "Feedback Router",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "Feedback Router": {
-            "main": [
-                [
-                    {
-                        "node": "ACK Handler",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "FALSE_POSITIVE Handler",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "CORRIGER Handler",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "RESOLVED Handler",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "STATUS Handler",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "ESCALATE Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ],
-                [
-                    {
-                        "node": "HELP Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "FALSE_POSITIVE Handler": {
-            "main": [
-                [
-                    {
-                        "node": "FALSE_POSITIVE Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "CORRIGER Handler": {
-            "main": [
-                [
-                    {
-                        "node": "CORRIGER Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "RESOLVED Handler": {
-            "main": [
-                [
-                    {
-                        "node": "RESOLVED Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "STATUS Handler": {
-            "main": [
-                [
-                    {
-                        "node": "STATUS Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "ACK Handler": {
-            "main": [
-                [
-                    {
-                        "node": "ACK Message",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "Fetch alert context": {
-            "main": [
-                [
-                    {
-                        "node": "Parse Feedback Command",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "ACK Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "FALSE_POSITIVE Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "CORRIGER Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "RESOLVED Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "ESCALATE Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "HELP Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "STATUS Message": {
-            "main": [
-                [
-                    {
-                        "node": "Escalation Alert (Twilio)",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
-        },
-        "Extract Service": {
-            "main": [
-                [
-                    {
-                        "node": "Fetch alert context",
-                        "type": "main",
-                        "index": 0
-                    }
-                ]
-            ]
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO feedback_corrections (source_id, corrected_state, corrected_at)\nVALUES (\n  '{{$json.source_id}}',\n  '{{$json.new_state}}',\n  NOW()\n);\n\nUPDATE afd_states \nSET \n    current_state = '{{ $json.new_state }}',\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}'\nRETURNING current_state;",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        0,
+        384
+      ],
+      "id": "ffecaa87-8ca4-414a-ad4e-4a3514af6ad7",
+      "name": "CORRIGER Handler",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
         }
+      }
     },
-    "active": false,
-    "settings": {
-        "executionOrder": "v1",
-        "binaryMode": "separate"
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "\nUPDATE afd_states \nSET \n    current_state = 'NOMINAL',\n    ack_time = COALESCE(ack_time, last_event_time),\n    updated_at = NOW()\nWHERE source_id = '{{ $json.source_id }}'\nRETURNING EXTRACT(EPOCH FROM (NOW() - last_event_time))::integer AS mttr_seconds;",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        0,
+        576
+      ],
+      "id": "814b8423-0060-4fb9-9f3d-f9428b95e2d5",
+      "name": "RESOLVED Handler",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
+        }
+      }
     },
-    "versionId": "7c99a461-ca98-448b-9dca-d7bc9a9e23a7",
-    "meta": {
-        "instanceId": "3cc12abac201836b73335193ababc7cd5c292dee27ca27a8da644aabb3ae79e1"
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT \n    source_id, \n    current_state, \n    last_event_time \nFROM afd_states \nORDER BY current_state DESC, last_event_time DESC;",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        0,
+        768
+      ],
+      "id": "6f32369e-78e0-46f4-8997-02e424a491d2",
+      "name": "STATUS Handler",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
+        }
+      }
     },
-    "id": "PCMX9uiPMyIde27A",
-    "tags": []
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.twilio.com/2010-04-01/Accounts/{{$env.TWILIO_ACCOUNT_SID}}/Messages.json",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBasicAuth",
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "From",
+              "value": "={{$env.TWILIO_WHATSAPP_FROM}}"
+            },
+            {
+              "name": "To",
+              "value": "={{$env.TWILIO_WHATSAPP_ESCALATION}}"
+            },
+            {
+              "name": "Body",
+              "value": "={{ $json.message}}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        448,
+        576
+      ],
+      "id": "577fd02a-6722-45d8-98f1-8367ee55e25d",
+      "name": "Escalation Alert (Twilio)",
+      "credentials": {
+        "httpBasicAuth": {
+          "id": "4DAEcjoYUOfq0mtw",
+          "name": "Unnamed credential"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE afd_states \nSET \n  current_state = 'RECOVERY',\n  ack_time      = NOW(),\n  updated_at    = NOW()\nWHERE source_id = '{{ $json.source_id }}';",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        0,
+        0
+      ],
+      "id": "f9d8eaef-eb3b-41d3-84ad-f20753c72802",
+      "name": "ACK Handler",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "(\n  -- First attempt: Find the specific service extracted from WhatsApp\n  SELECT \n      a.source_id, \n      a.current_state AS afd_state,\n      (SELECT message FROM logs l WHERE l.source_id = a.source_id ORDER BY classified_at DESC LIMIT 1) AS message,\n      1 as priority\n  FROM afd_states a\n  WHERE a.source_id = '{{ $json.extracted_service }}'\n)\nUNION ALL\n(\n  -- Fallback: If the above doesn't exist, get the most recent service overall\n  SELECT \n      a.source_id, \n      a.current_state AS afd_state,\n      (SELECT message FROM logs l WHERE l.source_id = a.source_id ORDER BY classified_at DESC LIMIT 1) AS message,\n      2 as priority\n  FROM afd_states a\n  ORDER BY a.last_event_time DESC\n  LIMIT 1\n)\nORDER BY priority ASC\nLIMIT 1;",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        -672,
+        576
+      ],
+      "id": "1c83d988-bc6a-4f0a-bf1b-23e0e7165562",
+      "name": "Fetch alert context",
+      "credentials": {
+        "postgres": {
+          "id": "OrJNfZC22BeBnYuu",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"message\": \"*PRISE EN CHARGE ENREGISTREE*\\n\\nL'intervention humaine a bien été notée dans le système.\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        0
+      ],
+      "id": "11467652-9fa8-4b3f-98fc-d5b7059f1e14",
+      "name": "ACK Message"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"message\": \"*RECLASSIFICATION REUSSIE*\\n\\nLe système a enregistré cette erreur de classification.\\nL'état du service est repassé en NOMINAL.\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        192
+      ],
+      "id": "24d20752-0753-4ca9-a6c0-7a0ee76b127e",
+      "name": "FALSE_POSITIVE Message"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={\n  \"message\": \"*RECLASSIFICATION APPLIQUÉE*\\n\\nLe service a été reclassifié avec succès en *{{ $json.current_state }}*.\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        384
+      ],
+      "id": "3a6359a6-e74b-4430-b4ff-2b97a0257e47",
+      "name": "CORRIGER Message"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={\n  \"message\": \"*INCIDENT RÉSOLU*\\n\\nLe service est repassé en état NOMINAL.\\n\\n*MTTR :* {{ Math.floor($json.mttr_seconds / 60) }} minutes.\"\n}\n",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        576
+      ],
+      "id": "a7e8d802-0e3a-4886-9c48-21e451fa7db8",
+      "name": "RESOLVED Message"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={ \n  \"message\": \"*ESCALATION REQUEST*\\n*Service:* apache\\n*State:* CRITICAL\\n*Message:* 127.0.0.1 - - [15/Jan/2024:14:23:01 +0000] \\\"POST /api/checkout 500 124\\\" CRITICAL: Database connection pool exhausted\\n\\n*Immediate intervention required*\" \n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        960
+      ],
+      "id": "8d976006-bb83-4649-913d-a822affba8ed",
+      "name": "ESCALATE Message"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"message\": \"GUIDE DES COMMANDES DISPONIBLES\\n\\n*ACK* : Confirmer la prise en charge de l'alerte.\\n\\n*FALSE POSITIVE* : Signaler une erreur de classification (l'état repassera en NOMINAL).\\n\\n*CORRIGER [ETAT]* : Forcer manuellement un nouvel état.\\nExemple : CORRIGER WARNING\\n\\n*RESOLVED* : Clôturer l'incident et calculer le temps de résolution (MTTR).\\n\\n*STATUS* : Obtenir l'état actuel de tous les services monitorés.\\n\\n*ESCALATE* : Transférer l'alerte à l'astreinte de niveau supérieur.\\n\\n*HELP* : Afficher ce menu d'aide.\"\n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        1152
+      ],
+      "id": "444f3f06-5167-4d2e-88a2-fb3a12f9a81c",
+      "name": "HELP Message"
+    },
+    {
+      "parameters": {
+        "jsCode": "const items = $input.all();\nlet statusList = items.map(item => {\n  return `• *${item.json.source_id}*: ${item.json.current_state}`;\n}).join('\\n');\n\nreturn {\n  message: `État actuel des services :*\\n${statusList}`\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        224,
+        768
+      ],
+      "id": "f426723d-fb36-42e0-b904-0a1cb164c0df",
+      "name": "STATUS Message"
+    },
+    {
+      "parameters": {
+        "jsCode": "// On récupère le texte avec la majuscule \"Body\"\nconst text = $input.item.json.body.Body; \n\nif (!text) {\n  return { extracted_service: \"unknown\" };\n}\n\n// On sépare les mots\nconst parts = text.split(\" \");\n\n/* Si l'admin écrit \"ESCALATE payment-api\" :\n  parts[0] = \"ESCALATE\"\n  parts[1] = \"payment-api\"\n*/\nconst service = parts[1] ? parts[1].toLowerCase() : \"all\"; \n\nreturn {\n  extracted_service: service\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -896,
+        576
+      ],
+      "id": "e34e4402-e9df-45f6-b25e-2f8e2d431f88",
+      "name": "Extract Service"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "WhatsApp Feedback Webhook": {
+      "main": [
+        [
+          {
+            "node": "Extract Service",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Feedback Command": {
+      "main": [
+        [
+          {
+            "node": "Feedback Router",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Feedback Router": {
+      "main": [
+        [
+          {
+            "node": "ACK Handler",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "FALSE_POSITIVE Handler",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "CORRIGER Handler",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "RESOLVED Handler",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "STATUS Handler",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "ESCALATE Message",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "HELP Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "FALSE_POSITIVE Handler": {
+      "main": [
+        [
+          {
+            "node": "FALSE_POSITIVE Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "CORRIGER Handler": {
+      "main": [
+        [
+          {
+            "node": "CORRIGER Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RESOLVED Handler": {
+      "main": [
+        [
+          {
+            "node": "RESOLVED Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "STATUS Handler": {
+      "main": [
+        [
+          {
+            "node": "STATUS Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "ACK Handler": {
+      "main": [
+        [
+          {
+            "node": "ACK Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch alert context": {
+      "main": [
+        [
+          {
+            "node": "Parse Feedback Command",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "ACK Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "FALSE_POSITIVE Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "CORRIGER Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RESOLVED Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "ESCALATE Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "HELP Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "STATUS Message": {
+      "main": [
+        [
+          {
+            "node": "Escalation Alert (Twilio)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Service": {
+      "main": [
+        [
+          {
+            "node": "Fetch alert context",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1",
+    "binaryMode": "separate"
+  },
+  "versionId": "680a44b0-c4a1-42cb-b0aa-d0cb368d32b5",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "cec0fdf9ad402c6f327a3e127a496886f6a2287d720a12376d03789c2a708588"
+  },
+  "id": "lfVTlb2ezHJDt5yP",
+  "tags": []
 }

--- a/workflows/log-ingestion.json
+++ b/workflows/log-ingestion.json
@@ -156,10 +156,16 @@
       "typeVersion": 2.6,
       "position": [
         -896,
-        880
+        992
       ],
-      "id": "0ece6fd9-edbe-46fd-ade0-87d3e1186dcf",
-      "name": "Insert rows in a table"
+      "id": "16afbc92-8566-4680-97ec-3b003773d923",
+      "name": "Insert rows in a table",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
@@ -170,9 +176,9 @@
       "typeVersion": 2,
       "position": [
         -1568,
-        976
+        1088
       ],
-      "id": "071c49e1-6895-4106-a1e7-1599b5d100f6",
+      "id": "475921b7-135b-4c17-83d6-201c24a934ed",
       "name": "Format Detector"
     },
     {
@@ -311,9 +317,9 @@
       "typeVersion": 3.4,
       "position": [
         -1344,
-        928
+        1040
       ],
-      "id": "bd2358e6-fa03-4e39-aed5-f12ed2f5d429",
+      "id": "c79fe767-2ec5-4077-bda4-fe88e81e5ad3",
       "name": "Switch"
     },
     {
@@ -325,9 +331,9 @@
       "typeVersion": 2,
       "position": [
         -1120,
-        480
+        672
       ],
-      "id": "c3479e02-f48b-433c-b691-241efa16771d",
+      "id": "60ded742-640c-48a6-a33e-9d0635089396",
       "name": "JSON Processor"
     },
     {
@@ -339,9 +345,9 @@
       "typeVersion": 2,
       "position": [
         -1120,
-        672
+        864
       ],
-      "id": "03cac4a7-1934-4d7d-bdab-739c15e6a926",
+      "id": "aa548b72-8ae7-490e-afae-33364729fbbc",
       "name": "Syslog Processor"
     },
     {
@@ -353,9 +359,9 @@
       "typeVersion": 2,
       "position": [
         -1120,
-        864
+        1056
       ],
-      "id": "efe3ecab-dc86-43dd-97f6-db822f6f6c2e",
+      "id": "2bd30d26-3302-4995-bf2d-4f0ab693ce80",
       "name": "Apache Processor"
     },
     {
@@ -367,9 +373,9 @@
       "typeVersion": 2,
       "position": [
         -1120,
-        1056
+        1248
       ],
-      "id": "05700416-1560-449c-8a32-9c05d8b4e340",
+      "id": "d87b39e8-a34e-48a6-95cc-a8969126cfa1",
       "name": "Plaintext Processor"
     },
     {
@@ -381,54 +387,66 @@
       "typeVersion": 2,
       "position": [
         -1120,
-        1248
+        1440
       ],
-      "id": "6b4073df-80bd-4674-bb2d-58729f627783",
+      "id": "2b209911-4f36-4297-8bd3-c24be7eba872",
       "name": "Unknown Processor"
     },
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT COALESCE(s.current_state, 'INFO') AS current_state, s.last_event_time FROM (SELECT 1) AS dummy LEFT JOIN afd_states s ON s.source_id = '{{ $json.source_id }}'",
+        "query": "SELECT\n  COALESCE(s.current_state, 'INFO')   AS current_state,\n  COALESCE(s.cascade_count, 0)        AS cascade_count,\n  s.last_event_time IS NULL           AS is_new_service,\n  COALESCE(\n    EXTRACT(EPOCH FROM (NOW() - s.last_event_time))::int,\n    999999\n  )                                   AS elapsed_since_last_sec,\n  COALESCE(\n    EXTRACT(EPOCH FROM (NOW() - s.cascade_start_time))::int,\n    999999\n  )                                   AS cascade_elapsed_sec\nFROM (SELECT 1) AS dummy\nLEFT JOIN afd_states s\n  ON s.source_id = '{{ $json.source_id }}'\n AND '{{ $json.source_id }}' <> ''",
         "options": {}
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
         -672,
-        880
+        992
       ],
-      "id": "587e7ca7-120b-44e8-be7d-5c205dca864a",
-      "name": "AFD State Read"
+      "id": "a7af5096-2c8d-4b8f-b22b-4148e5759d17",
+      "name": "AFD State Read",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
         "mode": "runOnceForEachItem",
-        "jsCode": "// WF1 - Code Node: AFD Engine + Regex Evaluation\n// Issue #5 | Branch: feat/05-wf1-afd-engine\n// LogSentinel - IA-01\n//\n// $json = output of \"AFD State Read\" (always 1 row, COALESCE LEFT JOIN)\n// $('Insert rows in a table').first().json = log row with id, source_id, message\n//\n// n8n mode: runOnceForEachItem\n// Phase 1 scope: ERROR_CASCADE, RECOVERY, cascade_count not implemented (Issue #13)\n\n\n// 0. ENV CONFIG\n// Requires N8N_BLOCK_ENV_ACCESS_IN_NODE=false in docker-compose (already set).\n\nconst TIMEOUT_WINDOW_SEC = parseInt($env.TIMEOUT_WINDOW ?? '300', 10);\nconst EFFECTIVE_TIMEOUT = Number.isFinite(TIMEOUT_WINDOW_SEC) && TIMEOUT_WINDOW_SEC > 0\n  ? TIMEOUT_WINDOW_SEC : 300;\n\n\n// 1. TRANSITION TABLE delta: Q x Sigma -> Q\n// Source: Issue #3, Section 3, 4x6 = 24 entries\n// Determinism: 1 output per (state, symbol) pair\n// Totality: all 24 entries defined\n// Monotonicity: delta(q, sigma_log) >= q except sigma_timeout (resets to INFO)\n// Absorption: delta(CRITICAL, sigma) = CRITICAL for all sigma != sigma_timeout\n\nconst TRANSITIONS = {\n  //           sigma_info    sigma_warn    sigma_error   sigma_crit    sigma_malformed  sigma_timeout\n  INFO:     { sigma_info: 'INFO',     sigma_warn: 'WARNING',  sigma_error: 'ERROR',    sigma_crit: 'CRITICAL', sigma_malformed: 'INFO',     sigma_timeout: 'INFO'     },\n  WARNING:  { sigma_info: 'INFO',     sigma_warn: 'WARNING',  sigma_error: 'ERROR',    sigma_crit: 'CRITICAL', sigma_malformed: 'WARNING',  sigma_timeout: 'INFO'     },\n  ERROR:    { sigma_info: 'WARNING',  sigma_warn: 'WARNING',  sigma_error: 'ERROR',    sigma_crit: 'CRITICAL', sigma_malformed: 'ERROR',    sigma_timeout: 'INFO'     },\n  CRITICAL: { sigma_info: 'CRITICAL', sigma_warn: 'CRITICAL', sigma_error: 'CRITICAL', sigma_crit: 'CRITICAL', sigma_malformed: 'CRITICAL', sigma_timeout: 'INFO'     },\n};\n\n// Note on delta(ERROR, sigma_info) = WARNING (not INFO):\n// Partial recovery - service responds again but we stay in WARNING.\n// Only sigma_timeout (prolonged silence) resets fully to INFO.\n\n\n// 2. REGEX PATTERNS in strict priority order\n// Priority: sigma_crit > sigma_error > sigma_warn > sigma_info > sigma_malformed\n// First match wins. sigma_malformed is the default (no regex). sigma_timeout is internal.\n\nconst REGEX_PATTERNS = [\n  {\n    symbol: 'sigma_crit',\n    // \\b prevents partial matches: \"uncritical\", \"non-fatal\" won't fire.\n    pattern: /\\b(CRITICAL|FATAL|EMERGENCY|PANIC|EMERG|KERN_CRIT|SEV1|P1)\\b/i,\n  },\n  {\n    symbol: 'sigma_error',\n    // HTTP 5xx via 5[0-9]{2}. Common exception class names included.\n    // Known false positive (Phase 1): 'GET /error-page 200' -> sigma_error because\n    // '/' is a non-word char so \\b fires before 'error' in the URL path.\n    // Issue #3 Section 5 edge case 1 was wrong on this. Fix in Phase 2 (Issue #4).\n    pattern: /\\b(ERROR|Exception|Traceback|FAILED|FAILURE|5[0-9]{2}|NullPointer|OutOfMemory|Segfault|SIGSEGV|SIGABRT)\\b/i,\n  },\n  {\n    symbol: 'sigma_warn',\n    // Negative lookahead TIMEOUT(?!_WINDOW): excludes \"TIMEOUT_WINDOW\" (internal config param).\n    pattern: /\\b(WARN|WARNING|SLOW|RETRY|DEPRECATED|TIMEOUT(?!_WINDOW)|HIGH_LATENCY|BACKPRESSURE|THROTTL)\\b/i,\n  },\n  {\n    symbol: 'sigma_info',\n    // HTTP 2xx via 2[0-9]{2}.\n    pattern: /\\b(INFO|DEBUG|TRACE|OK|SUCCESS|STARTED|STOPPED|HEALTHY|2[0-9]{2}|CONNECTED|INITIALIZED)\\b/i,\n  },\n  // sigma_malformed: no pattern, default in evaluateSymbol()\n  // sigma_timeout: internal temporal signal, never in REGEX_PATTERNS\n];\n\n\n// 3. PURE ENGINE FUNCTIONS\n\n/**\n * evaluateSymbol(message) -> symbol in Sigma\n * null/empty -> sigma_malformed before any regex. First match wins.\n */\nfunction evaluateSymbol(message) {\n  if (message === null || message === undefined) return 'sigma_malformed';\n  if (typeof message !== 'string' || message.trim() === '') return 'sigma_malformed';\n  for (const { symbol, pattern } of REGEX_PATTERNS) {\n    if (pattern.test(message)) return symbol;\n  }\n  return 'sigma_malformed';\n}\n\n/**\n * applyTransition(currentState, symbol) -> newState\n * Unknown state falls back to INFO. Unknown symbol leaves state unchanged.\n */\nfunction applyTransition(currentState, symbol) {\n  const row = TRANSITIONS[currentState];\n  if (!row) return TRANSITIONS['INFO'][symbol] ?? 'INFO';\n  return row[symbol] ?? currentState;\n}\n\n\n// 4. READ LOG DATA from the Insert node (carries id, source_id, message, etc.)\nconst logObject = $('Insert rows in a table').first().json;\nconst sourceId  = logObject.source_id ?? 'unknown';\nconst message   = logObject.message   ?? '';\nconst now       = new Date();\n\n\n// 5. READ CURRENT AFD STATE from $json (= \"AFD State Read\" output)\n// \"AFD State Read\" uses COALESCE with a LEFT JOIN so it always returns exactly 1 row.\n// New service: current_state = 'INFO', last_event_time = null\nconst stateRow = $json;\n\nlet currentState  = 'INFO';\nlet lastEventTime = now;\nlet isNewService  = true;\n\nif (stateRow?.current_state) {\n  // Normalize legacy 'NOMINAL' (schema.sql default from Phase 0) -> 'INFO' (Phase 1 q0)\n  currentState = (stateRow.current_state === 'NOMINAL') ? 'INFO' : stateRow.current_state;\n  if (!TRANSITIONS[currentState]) currentState = 'INFO';\n\n  if (stateRow.last_event_time) {\n    lastEventTime = new Date(stateRow.last_event_time);\n    isNewService  = false;\n    // last_event_time is null for new services (COALESCE returned INFO but no real row)\n  }\n}\n\n\n// 6. TEMPORAL RESET (sigma_timeout)\n// If no log received for TIMEOUT_WINDOW seconds: apply delta(q, sigma_timeout) first,\n// then delta(result, sigma_log). New services skip this (no last_event_time to compare).\n\nconst elapsedMs  = now - lastEventTime;\nconst elapsedSec = elapsedMs / 1000;\n\nlet stateAfterTimeout = currentState;\nlet timeoutApplied    = false;\n\nif (!isNewService && elapsedSec > EFFECTIVE_TIMEOUT) {\n  stateAfterTimeout = applyTransition(currentState, 'sigma_timeout');\n  timeoutApplied    = true;\n}\n\n\n// 7. SYMBOL EVALUATION AND TRANSITION\n\nconst symbol        = evaluateSymbol(message);\nconst newState      = applyTransition(stateAfterTimeout, symbol);\nconst previousState = currentState; // state before any transition (audit trail)\n\n\n// 8. RETURN ENRICHED OBJECT\n// \"AFD State Write\" node (after this) runs:\n//   INSERT INTO afd_states ... ON CONFLICT DO UPDATE using $json.afd_state etc.\n// \"Log State Write\" node (after this) runs:\n//   UPDATE logs SET afd_state, afd_symbol, previous_state WHERE id = $json.id\n\nreturn {\n  ...logObject,           // all fields from Insert node (including id)\n  afd_symbol:      symbol,\n  afd_state:       newState,\n  previous_state:  previousState,\n  source_id:       sourceId,\n  is_new_service:  isNewService,\n  timeout_applied: timeoutApplied,\n  elapsed_sec:     Math.round(elapsedSec),\n  timeout_window:  EFFECTIVE_TIMEOUT,\n  engine_ts:       now.toISOString(),\n  // Not in Phase 1: cascade_count, cascade_start_time, ERROR_CASCADE, RECOVERY (Issue #13)\n};\n"
+        "jsCode": "// 0. CONFIG\nconst TIMEOUT_WINDOW_SEC  = parseInt($env.TIMEOUT_WINDOW    ?? '300', 10);\nconst CASCADE_THRESHOLD   = parseInt($env.CASCADE_THRESHOLD ?? '3',   10);\nconst CASCADE_WINDOW_SEC  = parseInt($env.CASCADE_WINDOW    ?? '60',  10);\n\nconst EFFECTIVE_TIMEOUT   = Number.isFinite(TIMEOUT_WINDOW_SEC)  && TIMEOUT_WINDOW_SEC  > 0 ? TIMEOUT_WINDOW_SEC  : 300;\nconst EFFECTIVE_THRESHOLD = Number.isFinite(CASCADE_THRESHOLD)   && CASCADE_THRESHOLD   > 0 ? CASCADE_THRESHOLD   : 3;\nconst EFFECTIVE_CASCADE   = Number.isFinite(CASCADE_WINDOW_SEC)  && CASCADE_WINDOW_SEC  > 0 ? CASCADE_WINDOW_SEC  : 60;\n\n\n// 1. TRANSITION TABLE 6×6 (Issue #12)\nconst TRANSITIONS = {\n  INFO:          { sigma_info:'INFO',     sigma_warn:'WARNING',  sigma_error:'ERROR',    sigma_crit:'CRITICAL', sigma_ack:'INFO',      sigma_malformed:'INFO',          sigma_timeout:'INFO'  },\n  WARNING:       { sigma_info:'INFO',     sigma_warn:'WARNING',  sigma_error:'ERROR',    sigma_crit:'CRITICAL', sigma_ack:'WARNING',   sigma_malformed:'WARNING',       sigma_timeout:'INFO'  },\n  ERROR:         { sigma_info:'WARNING',  sigma_warn:'WARNING',  sigma_error:'ERROR',    sigma_crit:'CRITICAL', sigma_ack:'ERROR',     sigma_malformed:'ERROR',         sigma_timeout:'INFO'  },\n  ERROR_CASCADE: { sigma_info:'WARNING',  sigma_warn:'ERROR',    sigma_error:'ERROR',    sigma_crit:'CRITICAL', sigma_ack:'ERROR',     sigma_malformed:'ERROR_CASCADE', sigma_timeout:'INFO'  },\n  CRITICAL:      { sigma_info:'CRITICAL', sigma_warn:'CRITICAL', sigma_error:'CRITICAL', sigma_crit:'CRITICAL', sigma_ack:'RECOVERY',  sigma_malformed:'CRITICAL',      sigma_timeout:'INFO'  },\n  RECOVERY:      { sigma_info:'INFO',     sigma_warn:'WARNING',  sigma_error:'ERROR',    sigma_crit:'CRITICAL', sigma_ack:'RECOVERY',  sigma_malformed:'RECOVERY',      sigma_timeout:'INFO'  },\n};\n\n// 2. REGEX PATTERNS\nconst REGEX_PATTERNS = [\n  { symbol: 'sigma_crit',  pattern: /\\b(CRITICAL|FATAL|EMERGENCY|PANIC|EMERG|KERN_CRIT|SEV1|P1)\\b/i },\n  { symbol: 'sigma_error', pattern: /\\b(ERROR|Exception|Traceback|FAILED|FAILURE|5[0-9]{2}|NullPointer|OutOfMemory|Segfault|SIGSEGV|SIGABRT)\\b/i },\n  { symbol: 'sigma_warn',  pattern: /\\b(WARN|WARNING|SLOW|RETRY|DEPRECATED|TIMEOUT(?!_WINDOW)|HIGH_LATENCY|BACKPRESSURE|THROTTL)\\b/i },\n  { symbol: 'sigma_info',  pattern: /\\b(INFO|DEBUG|TRACE|OK|SUCCESS|STARTED|STOPPED|HEALTHY|2[0-9]{2}|CONNECTED|INITIALIZED)\\b/i },\n];\nconst ACK_PATTERN = /\\b(__AFD_ACK__)\\b/;\n\nfunction evaluateSymbol(message) {\n  if (message === null || message === undefined) return 'sigma_malformed';\n  if (typeof message !== 'string' || message.trim() === '') return 'sigma_malformed';\n  if (ACK_PATTERN.test(message)) return 'sigma_ack';\n  for (const { symbol, pattern } of REGEX_PATTERNS) {\n    if (pattern.test(message)) return symbol;\n  }\n  return 'sigma_malformed';\n}\n\nfunction applyTransition(state, symbol) {\n  const row = TRANSITIONS[state];\n  if (!row) return TRANSITIONS['INFO'][symbol] ?? 'INFO';\n  return row[symbol] ?? state;\n}\n\n\n// 3. READ LOG\nconst logObject = $('Insert rows in a table').item.json;\nconst sourceId  = logObject.source_id ?? 'unknown';\nconst message   = logObject.message   ?? '';\nconst logId     = logObject.id        ?? null;\nconst now       = new Date();\n\n\n// 4. READ AFD STATE\n// All elapsed-time values are now computed inside PostgreSQL (NOW() - stored_time)\n// so the n8n / PostgreSQL clock skew never affects the logic.\nconst stateRow = $json;\n\nlet rawState = stateRow?.current_state ?? 'INFO';\nif (rawState === 'NOMINAL')  rawState = 'INFO';\nif (rawState === 'DEGRADED') rawState = 'WARNING';\nlet currentState = TRANSITIONS[rawState] ? rawState : 'INFO';\n\nconst isNewService      = stateRow?.is_new_service !== false;   // true when no prior row\nconst cascadeCount      = parseInt(stateRow?.cascade_count ?? '0', 10) || 0;\nconst elapsedSec        = Number(stateRow?.elapsed_since_last_sec ?? 999999);\nconst cascadeElapsedSec = Number(stateRow?.cascade_elapsed_sec   ?? 999999);\n\n\n// 5. TEMPORAL RESET (sigma_timeout)\n// Uses SQL-computed elapsedSec — no cross-clock comparison.\nlet stateAfterTimeout = currentState;\nlet timeoutApplied    = false;\nlet newCascadeCount   = cascadeCount;\n\nif (!isNewService && elapsedSec > EFFECTIVE_TIMEOUT) {\n  stateAfterTimeout = applyTransition(currentState, 'sigma_timeout');\n  timeoutApplied    = true;\n  newCascadeCount   = 0;\n}\n\n\n// 6. SYMBOL EVALUATION AND TRANSITION WITH CASCADE WINDOW\n// cascadeElapsedSec is also SQL-computed — no cross-clock comparison.\nconst symbol      = evaluateSymbol(message);\nconst rawNewState = applyTransition(stateAfterTimeout, symbol);\n\nlet newState      = rawNewState;\n// cascade_reset tells AFD State Write how to update cascade_start_time:\n//   'reset_now'  → start fresh window   → PostgreSQL NOW()\n//   'reset_null' → leave error territory → NULL\n//   'keep'       → stay in window        → preserve existing value\nlet cascade_reset = 'keep';\n\nif (rawNewState === 'ERROR') {\n  if (cascadeElapsedSec > EFFECTIVE_CASCADE) {\n    newCascadeCount = 1;\n    cascade_reset   = 'reset_now';\n    newState        = 'ERROR';\n  } else {\n    newCascadeCount = cascadeCount + 1;\n    cascade_reset   = 'keep';\n    if (newCascadeCount >= EFFECTIVE_THRESHOLD) {\n      newState = 'ERROR_CASCADE';\n    }\n  }\n} else if (rawNewState === 'ERROR_CASCADE') {\n  newCascadeCount = cascadeCount + 1;\n  cascade_reset   = 'keep';\n} else {\n  if (currentState === 'ERROR' || currentState === 'ERROR_CASCADE') {\n    newCascadeCount = 0;\n    cascade_reset   = 'reset_null';\n  }\n}\n\nconst previousState = currentState;\n\n\n// 7. OUTPUT\nreturn {\n  ...logObject,\n  afd_symbol:     symbol,\n  afd_state:      newState,\n  previous_state: previousState,\n  source_id:      sourceId,\n  id:             logId,\n  cascade_count:  newCascadeCount,\n  cascade_reset:  cascade_reset,\n  is_new_service:   isNewService,\n  timeout_applied:  timeoutApplied,\n  elapsed_sec:      Math.round(elapsedSec),\n  cascade_elapsed:  Math.round(cascadeElapsedSec),\n  cascade_threshold: EFFECTIVE_THRESHOLD,\n  cascade_window:   EFFECTIVE_CASCADE,\n  engine_ts:        now.toISOString(),\n  engine_version:   'v2',\n};"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
         -448,
-        880
+        992
       ],
-      "id": "6461c4c4-65ef-46c5-8287-38a3e2dc4d62",
+      "id": "518a9912-6c99-431c-b86b-32aa2cd59edc",
       "name": "AFD Engine"
     },
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO afd_states (source_id, current_state, previous_state, last_symbol, last_event_time, updated_at) VALUES ('{{ $json.source_id }}', '{{ $json.afd_state }}', '{{ $json.previous_state }}', '{{ $json.afd_symbol }}', NOW(), NOW()) ON CONFLICT (source_id) DO UPDATE SET current_state = EXCLUDED.current_state, previous_state = EXCLUDED.previous_state, last_symbol = EXCLUDED.last_symbol, last_event_time = EXCLUDED.last_event_time, updated_at = EXCLUDED.updated_at",
+        "query": "INSERT INTO afd_states (\n  source_id, current_state, previous_state, last_symbol,\n  last_event_time, cascade_count, cascade_start_time, updated_at\n)\nVALUES (\n  '{{ $json.source_id }}',\n  '{{ $json.afd_state }}',\n  '{{ $json.previous_state }}',\n  '{{ $json.afd_symbol }}',\n  NOW(),\n  {{ $json.cascade_count }},\n  CASE '{{ $json.cascade_reset }}'\n    WHEN 'reset_now' THEN NOW()\n    ELSE NULL\n  END,\n  NOW()\n)\nON CONFLICT (source_id) DO UPDATE SET\n  current_state      = EXCLUDED.current_state,\n  previous_state     = EXCLUDED.previous_state,\n  last_symbol        = EXCLUDED.last_symbol,\n  last_event_time    = NOW(),\n  cascade_count      = EXCLUDED.cascade_count,\n  cascade_start_time = CASE '{{ $json.cascade_reset }}'\n    WHEN 'reset_now'  THEN NOW()\n    WHEN 'reset_null' THEN NULL\n    ELSE afd_states.cascade_start_time\n  END,\n  updated_at         = NOW()",
         "options": {}
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
       "position": [
         -224,
-        784
+        896
       ],
-      "id": "d53fa4dd-96e0-4691-b27e-f925fda00a2d",
-      "name": "AFD State Write"
+      "id": "c78d35a2-70c1-4147-988c-0a327a4f0469",
+      "name": "AFD State Write",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
@@ -440,10 +458,16 @@
       "typeVersion": 2.6,
       "position": [
         -224,
-        976
+        1088
       ],
-      "id": "1af39269-4e5f-4f1c-a742-e29a5db465bd",
-      "name": "Log State Write"
+      "id": "66396da3-0030-4459-aac5-8c81598d3b32",
+      "name": "Log State Write",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
@@ -534,6 +558,30 @@
                 },
                 "conditions": [
                   {
+                    "id": "46d43c5b-b766-4bf2-867c-06beaa2db19e",
+                    "leftValue": "={{ $json.afd_state }}",
+                    "rightValue": "RECOVERY",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "RECOVERY Handler"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
                     "id": "ff408d4f-2f53-4e9a-bbfc-7d9bfa22e67d",
                     "leftValue": "={{ ['CRITICAL', 'ERROR_CASCADE'].includes($json.afd_state) }}",
                     "rightValue": "",
@@ -557,9 +605,9 @@
       "typeVersion": 3.4,
       "position": [
         -224,
-        528
+        608
       ],
-      "id": "4c47b42d-4f0a-408d-9c02-6a9a672838ee",
+      "id": "b5548ea9-70af-4abd-9b44-05396629c915",
       "name": "AFD State Switch Router"
     },
     {
@@ -577,28 +625,15 @@
         0,
         192
       ],
-      "id": "eb9609a6-8d27-405c-a5c7-a495465f4c56",
+      "id": "1604aa42-69ff-4b13-89c7-e7372f770ab0",
       "name": "Send an Email",
-      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f"
-    },
-    {
-      "parameters": {
-        "fromEmail": "={{$env.SMTP_FROM}}",
-        "toEmail": "={{$env.SMTP_TO}}",
-        "subject": "=ERROR - {{$json.source_id}}",
-        "emailFormat": "text",
-        "text": "=Error detected:\n{{$json.message}}\n\nPlease investigate immediately.",
-        "options": {}
-      },
-      "type": "n8n-nodes-base.emailSend",
-      "typeVersion": 2.1,
-      "position": [
-        0,
-        576
-      ],
-      "id": "8d365d24-8e27-4154-87cf-048a284137c4",
-      "name": "Send an Email1",
-      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f"
+      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f",
+      "credentials": {
+        "smtp": {
+          "id": "HZ4ykWGX2Lk64qkQ",
+          "name": "SMTP account"
+        }
+      }
     },
     {
       "parameters": {
@@ -612,7 +647,7 @@
         0,
         384
       ],
-      "id": "ebae0b69-adf8-4487-8bc8-f4641147e9ff",
+      "id": "37a95bdf-285c-4ef1-9c38-64845f632e5b",
       "name": "WARNING Message"
     },
     {
@@ -627,7 +662,7 @@
         0,
         0
       ],
-      "id": "79762da5-74c4-4ce8-a126-22d96f43b133",
+      "id": "e6b6ea17-b51c-498c-9ba7-97315ffef4b3",
       "name": "INFO Message"
     },
     {
@@ -642,7 +677,7 @@
         0,
         768
       ],
-      "id": "c227d851-8939-4c92-ad85-1bb69bbc5bce",
+      "id": "f51ab939-4549-47b0-8a7c-91fd17a80b1f",
       "name": "ERROR Message"
     },
     {
@@ -657,7 +692,7 @@
         0,
         960
       ],
-      "id": "dc30af4a-8981-48c0-96c2-3fc818a38afa",
+      "id": "adaa104f-34ab-4a04-8ac3-6ed1ba9f9f38",
       "name": "CRITICAL Message"
     },
     {
@@ -672,9 +707,9 @@
       "typeVersion": 1.5,
       "position": [
         224,
-        464
+        656
       ],
-      "id": "0d275027-a336-4a6b-a237-71435686ad8b",
+      "id": "7e052f5f-6599-41a0-9d04-734fcc692a26",
       "name": "Final Response"
     },
     {
@@ -688,9 +723,9 @@
       "typeVersion": 2.1,
       "position": [
         -1792,
-        976
+        1088
       ],
-      "id": "5e04e5d5-375e-4532-88d1-64aab3232379",
+      "id": "4a046adb-5eb5-42f6-9a46-56b96ccd0582",
       "name": "Webhook1",
       "webhookId": "a489eedb-7558-4cf6-b7ed-ec74ce5c03bd"
     },
@@ -704,10 +739,16 @@
       "typeVersion": 2.6,
       "position": [
         0,
-        1152
+        1344
       ],
-      "id": "05e10f63-cc38-4bb7-852c-ea905d323aeb",
-      "name": "Get Recent Logs"
+      "id": "34166114-7eb5-4972-8dfe-85270ca8104d",
+      "name": "Get Recent Logs",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
@@ -717,9 +758,9 @@
       "typeVersion": 2,
       "position": [
         224,
-        1152
+        1344
       ],
-      "id": "fd8a4258-250b-4116-869c-9ab38a2a8aef",
+      "id": "59d7735f-00cd-49c8-89d8-52e9b51eea98",
       "name": "Format Recent Logs"
     },
     {
@@ -730,9 +771,9 @@
       "typeVersion": 2,
       "position": [
         1120,
-        1152
+        1344
       ],
-      "id": "1d3b3319-8c8e-45d0-b781-260f89e0ea79",
+      "id": "26217a09-44f0-44a2-be68-0ef5a37948d3",
       "name": "Format Alert Message"
     },
     {
@@ -747,11 +788,17 @@
       "typeVersion": 2.1,
       "position": [
         1344,
-        1152
+        1344
       ],
-      "id": "2f7b8c25-2d40-479a-b6ab-180ffa5eb9da",
+      "id": "a12e2eef-1305-4217-89df-8ec2ead3b882",
       "name": "Alert Email",
-      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f"
+      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f",
+      "credentials": {
+        "smtp": {
+          "id": "HZ4ykWGX2Lk64qkQ",
+          "name": "SMTP account"
+        }
+      }
     },
     {
       "parameters": {
@@ -763,10 +810,16 @@
       "typeVersion": 2.6,
       "position": [
         1344,
-        1344
+        1536
       ],
-      "id": "6dc95465-356a-4d66-9617-ff9192a69233",
-      "name": "Reset ACK Time"
+      "id": "4f5da6a7-0de9-4357-94ad-7ece892c6f5e",
+      "name": "Reset ACK Time",
+      "credentials": {
+        "postgres": {
+          "id": "nfpFHuBjkrDPl751",
+          "name": "Postgres account"
+        }
+      }
     },
     {
       "parameters": {
@@ -798,10 +851,16 @@
       "typeVersion": 4.4,
       "position": [
         1344,
-        960
+        1152
       ],
-      "id": "aab565e4-8ead-4185-97cf-84fd75df1b3b",
-      "name": "Twilio WhatsApp Alert"
+      "id": "58c5e497-d581-4966-985d-ef2c5b32d259",
+      "name": "Twilio WhatsApp Alert",
+      "credentials": {
+        "httpBasicAuth": {
+          "id": "CWeWIvKiHuGZeewK",
+          "name": "Unnamed credential"
+        }
+      }
     },
     {
       "parameters": {
@@ -811,9 +870,9 @@
       "typeVersion": 2,
       "position": [
         448,
-        1152
+        1344
       ],
-      "id": "61bd5dc7-57e9-42b7-9f2b-42341c9cccae",
+      "id": "5d451687-2e4c-4ff2-a644-74f95cf6983a",
       "name": "Build LLM Prompt"
     },
     {
@@ -831,10 +890,16 @@
       "typeVersion": 4.4,
       "position": [
         672,
-        1152
+        1344
       ],
-      "id": "4d0bf512-307a-456b-8806-5bcdad8efb7e",
-      "name": "Groq API Call"
+      "id": "8ec0744d-88ba-44d4-87ab-98b52aab50ee",
+      "name": "Groq API Call",
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "iprK9yIrmvNmjond",
+          "name": "Bearer Auth account"
+        }
+      }
     },
     {
       "parameters": {
@@ -844,10 +909,50 @@
       "typeVersion": 2,
       "position": [
         896,
+        1344
+      ],
+      "id": "2d09be6b-23d2-43b3-a32a-c2c49085c08f",
+      "name": "Parse LLM Response"
+    },
+    {
+      "parameters": {
+        "fromEmail": "={{$env.SMTP_FROM}}",
+        "toEmail": "={{$env.SMTP_TO}}",
+        "subject": "=ERROR - {{$json.source_id}}",
+        "emailFormat": "text",
+        "text": "=Error detected:\n{{$json.message}}\n\nPlease investigate immediately.",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [
+        0,
+        576
+      ],
+      "id": "a1f3fa73-be46-4385-94db-08926506be3b",
+      "name": "Send an Email1",
+      "webhookId": "53180bb1-81f6-432f-bd65-23720f897a7f",
+      "credentials": {
+        "smtp": {
+          "id": "HZ4ykWGX2Lk64qkQ",
+          "name": "SMTP account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"status\": \"RECOVERY\", \n  \"message\": \"monitoring_post_incident\" \n}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        0,
         1152
       ],
-      "id": "c068600b-a385-48b9-b098-497ee99fbd36",
-      "name": "Parse LLM Response"
+      "id": "8e10a686-d9cc-4e29-a939-f43f8c78c1c5",
+      "name": "RECOVERY Message"
     }
   ],
   "pinData": {},
@@ -1035,6 +1140,13 @@
         ],
         [
           {
+            "node": "RECOVERY Message",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
             "node": "Get Recent Logs",
             "type": "main",
             "index": 0
@@ -1177,6 +1289,17 @@
           }
         ]
       ]
+    },
+    "RECOVERY Message": {
+      "main": [
+        [
+          {
+            "node": "Final Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "active": false,
@@ -1184,10 +1307,11 @@
     "executionOrder": "v1",
     "binaryMode": "separate"
   },
-  "versionId": "cc7e14a0-47fa-429a-a095-0b87ccdcbc1c",
+  "versionId": "efad971e-c270-4705-bca8-ec3caa0efcf4",
   "meta": {
-    "instanceId": "3cc12abac201836b73335193ababc7cd5c292dee27ca27a8da644aabb3ae79e1"
+    "templateCredsSetupCompleted": true,
+    "instanceId": "cec0fdf9ad402c6f327a3e127a496886f6a2287d720a12376d03789c2a708588"
   },
-  "id": "lENlBdSR0FEiGn7r",
+  "id": "cLFqCbfUlew7fyVM",
   "tags": []
 }


### PR DESCRIPTION
##  AFD Engine v2 : 6 États + Cascade Temporelle

### What changed

Extended the AFD Engine from 4 states to 6 states by adding ERROR_CASCADE and RECOVERY.
No states were renamed — INFO/WARNING/ERROR/CRITICAL remain unchanged to avoid regressions.

### New states

**ERROR_CASCADE** — triggered when a service emits N consecutive ERROR signals within a
configurable time window. Represents an escalation detected by context, not by a single log.
Routes to the same branch as CRITICAL in the Switch Router (LLM + WhatsApp alert).

**RECOVERY** — triggered exclusively by the ACK command from WF2. Represents the
post-incident monitoring phase after a human acknowledges a CRITICAL alert. No alert is sent,
the system watches silently until the service stabilises back to INFO.

### Transition table (6x6)

| State \ Symbol | sigma_info | sigma_warn | sigma_error | sigma_crit | sigma_ack | sigma_timeout |
|---|---|---|---|---|---|---|
| INFO | INFO | WARNING | ERROR | CRITICAL | INFO | INFO |
| WARNING | INFO | WARNING | ERROR | CRITICAL | WARNING | INFO |
| ERROR | WARNING | WARNING | CASCADE_LOGIC | CRITICAL | ERROR | INFO |
| ERROR_CASCADE | WARNING | ERROR | ERROR_CASCADE | CRITICAL | ERROR | INFO |
| CRITICAL | CRITICAL | CRITICAL | CRITICAL | CRITICAL | RECOVERY | INFO |
| RECOVERY | INFO | WARNING | ERROR | CRITICAL | RECOVERY | INFO |

CASCADE_LOGIC is not a real state — it is a placeholder resolved at runtime by the cascade
window logic described below.

### Cascade window logic

When the current state is ERROR and the incoming symbol is sigma_error, instead of applying
a static transition the engine checks two configurable parameters from the environment:

- `CASCADE_THRESHOLD` (default: 3) — number of consecutive errors required
- `CASCADE_WINDOW` (default: 60s) — time window in seconds

If no cascade window is open yet, or the last window expired, a new one starts and
cascade_count is set to 1, state stays ERROR.

If inside an open window, cascade_count increments. When cascade_count reaches
CASCADE_THRESHOLD, state becomes ERROR_CASCADE.

Any transition that leaves the ERROR or ERROR_CASCADE state via a non-error symbol resets
both cascade_count and cascade_start_time to zero/null.

### Nodes changed

**AFD State Read** — query extended to also read cascade_count and cascade_start_time
from afd_states, so the engine receives the full context on each execution.

**AFD Engine** — full replacement of the Code node. Adds the 6x6 transition table, cascade
window logic, and RECOVERY handling. Also fixes `.first()` to `.item` for correctness in the
runOnceForEachItem execution mode.

**AFD State Write** — INSERT/UPDATE query extended to persist cascade_count and
cascade_start_time. cascade_start_time is serialised as a plain timestamp string
(YYYY-MM-DD HH:MM:SS.mmm) and handled with NULLIF to store NULL when absent.

**AFD State Switch Router** — added a fifth branch for RECOVERY that routes to a simple
Set node returning `{ status: "RECOVERY", message: "monitoring_post_incident" }`. No LLM
call, no alert.

**WF2 ACK Handler** — updated to set current_state = 'RECOVERY' instead of 'NOMINAL',
correctly applying delta(CRITICAL, sigma_ack) = RECOVERY.

### Environment variables added

```env
CASCADE_THRESHOLD=3
CASCADE_WINDOW=60
```

Both have hardcoded defaults in the engine so the workflow runs without them if not set.

### Validation

```
Log 1 (ERROR) -> state: ERROR,         cascade_count: 1
Log 2 (ERROR) -> state: ERROR,         cascade_count: 2
Log 3 (ERROR) -> state: ERROR_CASCADE, cascade_count: 3
```

DB confirmed:
```
 source_id  | current_state | cascade_count | cascade_start_time
------------+---------------+---------------+----------------------------
 db-service | ERROR_CASCADE |             3 | 2026-05-11 08:20:50.100238
```